### PR TITLE
Use default constructor for VerletList 

### DIFF
--- a/src/force_lj_cabana_neigh.cpp
+++ b/src/force_lj_cabana_neigh.cpp
@@ -49,9 +49,7 @@
 
 #include<force_lj_cabana_neigh.h>
 
-Force::Force(System* system, bool half_neigh_):neigh_list_full(init_fullneigh_list()),
-					       neigh_list_half(init_halfneigh_list()),
-					       half_neigh(half_neigh_),neigh_cut(0.0) {
+Force::Force(System* system, bool half_neigh_):half_neigh(half_neigh_),neigh_cut(0.0) {
   ntypes = system->ntypes;
 
   lj1 = t_fparams("ForceLJCabanaNeigh::lj1",ntypes,ntypes);
@@ -80,20 +78,6 @@ void Force::init_coeff(T_X_FLOAT neigh_cut_, std::vector<int> force_types, std::
       stack_cutsq[i][j] = cut*cut;
     }
   }
-}
-
-// No default constructor for Cabana::VerletList
-t_verletlist_full Force::init_fullneigh_list() {
-  AoSoA xvf (1);
-  auto x = xvf.slice<Positions>();
-  t_verletlist_full neigh_list_full( x, 0, x.size(), 1.0, 1.0, (const double[]){0.0,0.0,0.0}, (const double[]){1.0,1.0,1.0} );
-  return neigh_list_full;
-}
-t_verletlist_half Force::init_halfneigh_list() {
-  AoSoA xvf (1);
-  auto x = xvf.slice<Positions>();
-  t_verletlist_half neigh_list_half( x, 0, x.size(), 1.0, 1.0, (const double[]){0.0,0.0,0.0}, (const double[]){1.0,1.0,1.0} );
-  return neigh_list_half;
 }
 
 void Force::create_neigh_list(System* system) {

--- a/src/force_lj_cabana_neigh.h
+++ b/src/force_lj_cabana_neigh.h
@@ -64,9 +64,6 @@ private:
 
   int step;
 
-  t_verletlist_full init_fullneigh_list();
-  t_verletlist_half init_halfneigh_list();
-
   typedef Kokkos::View<T_F_FLOAT**> t_fparams;
   typedef Kokkos::View<const T_F_FLOAT**,
       Kokkos::MemoryTraits<Kokkos::RandomAccess>> t_fparams_rnd;


### PR DESCRIPTION
Remove local "fake constructor", no longer necessary to make neighbor lists data members for use in force functors