### PR TITLE
Include what is used & remove Cabana_Core for now 

### DIFF
--- a/src/binning_cabana.h
+++ b/src/binning_cabana.h
@@ -49,7 +49,9 @@
 
 #ifndef BINNING_CABANA_H
 #define BINNING_CABANA_H
-//#include<Kokkos_Sort.hpp>
+#include <Cabana_LinkedCellList.hpp>
+#include <Cabana_Slice.hpp>
+
 #include <types.h>
 #include <system.h>
 

--- a/src/cabanamd.h
+++ b/src/cabanamd.h
@@ -47,6 +47,7 @@
 //  Questions? Contact Christian R. Trott (crtrott@sandia.gov)
 //************************************************************************
 
+#include <Cabana_Slice.hpp>
 #include <types.h>
 
 #include<system.h>

--- a/src/comm_serial.h
+++ b/src/comm_serial.h
@@ -49,6 +49,8 @@
 
 #ifndef COMM_SERIAL_H
 #define COMM_SERIAL_H
+#include <Cabana_Slice.hpp>
+
 #include <types.h>
 #include <system.h>
 

--- a/src/force_lj_cabana_neigh.h
+++ b/src/force_lj_cabana_neigh.h
@@ -49,6 +49,9 @@
 
 #ifndef FORCE_LJ_CABANA_NEIGH_H
 #define FORCE_LJ_CABANA_NEIGH_H
+#include <Cabana_NeighborList.hpp>
+#include <Cabana_Slice.hpp>
+
 #include<vector>
 #include<types.h>
 #include<system.h>

--- a/src/input.h
+++ b/src/input.h
@@ -47,6 +47,8 @@
 //  Questions? Contact Christian R. Trott (crtrott@sandia.gov)
 //************************************************************************
 
+#include <Cabana_Slice.hpp>
+
 #include <vector>
 #include <types.h>
 #include <system.h>

--- a/src/integrator_nve.h
+++ b/src/integrator_nve.h
@@ -49,6 +49,7 @@
 
 #ifndef INTEGRATOR_NVE_H
 #define INTEGRATOR_NVE_H
+#include <Cabana_AoSoA.hpp>
 
 #include <types.h>
 #include <system.h>

--- a/src/property_kine.h
+++ b/src/property_kine.h
@@ -48,6 +48,8 @@
 //************************************************************************
 
 
+#include <Cabana_Slice.hpp>
+
 #include <types.h>
 #include <system.h>
 #include <comm_serial.h>

--- a/src/property_temperature.h
+++ b/src/property_temperature.h
@@ -47,6 +47,8 @@
 //  Questions? Contact Christian R. Trott (crtrott@sandia.gov)
 //************************************************************************
 
+#include <Cabana_Slice.hpp>
+
 #include <types.h>
 #include <system.h>
 #include <comm_serial.h>

--- a/src/system.h
+++ b/src/system.h
@@ -49,6 +49,8 @@
 
 #ifndef SYSTEM_H
 #define SYSTEM_H
+#include <Cabana_Slice.hpp>
+
 #include<types.h>
 
 class System {

--- a/src/types.h
+++ b/src/types.h
@@ -50,7 +50,10 @@
 #ifndef TYPES_H
 #define TYPES_H
 #include<Kokkos_Core.hpp>
-#include<Cabana_Core.hpp>
+#include<Cabana_AoSoA.hpp>
+#include<Cabana_VerletList.hpp>
+#include<CabanaCore_config.hpp>
+
 #define VECLEN 16
 
 // Module Types etc


### PR DESCRIPTION
(Closes #1)

Once Cabana_Core deprecated functions are removed, Core could be included instead (ECP-copa/Cabana#106)