### PR TITLE
Use Cabana cmake defines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ endif()
 option(Cabana_ENABLE_Cuda "Build CabanaMD with Cuda support" OFF)
 if( Cabana_ENABLE_Cuda )
   enable_language( CUDA )
-  add_definitions(-DCabanaMD_ENABLE_Cuda)
 endif()
 
 set(CABANA_SUPPORTED_DEVICES Serial Pthread OpenMP Cuda)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,13 +52,13 @@
 // CabanaMD can be used as a library
 // This main file is simply a driver
 
-#ifdef CabanaMD_ENABLE_MPI
+#ifdef Cabana_ENABLE_MPI
 #include "mpi.h"
 #endif
 
 int main(int argc, char* argv[]) {
 
-   #ifdef CabanaMD_ENABLE_MPI
+   #ifdef Cabana_ENABLE_MPI
    MPI_Init(&argc,&argv);
    #endif
 
@@ -75,7 +75,7 @@ int main(int argc, char* argv[]) {
 
    cabanamd.shutdown();
 
-   #ifdef CabanaMD_ENABLE_MPI
+   #ifdef Cabana_ENABLE_MPI
    MPI_Finalize();
    #endif
 }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -48,7 +48,7 @@
 //************************************************************************
 
 #include<system.h>
-#ifdef CabanaMD_ENABLE_MPI
+#ifdef Cabana_ENABLE_MPI
 #include<mpi.h>
 #endif
 System::System() {
@@ -64,7 +64,7 @@ System::System() {
   sub_domain_hi_x = sub_domain_hi_y = sub_domain_hi_z = 0.0;
   sub_domain_lo_x = sub_domain_lo_y = sub_domain_lo_z = 0.0;
   mvv2e = boltz = dt = 0.0;
-#ifdef CabanaMD_ENABLE_MPI
+#ifdef Cabana_ENABLE_MPI
   int proc_rank;
   MPI_Comm_rank(MPI_COMM_WORLD, &proc_rank);
   do_print = proc_rank == 0;

--- a/src/types.h
+++ b/src/types.h
@@ -108,7 +108,7 @@ using t_tuple = Cabana::MemberTypes<T_FLOAT[3], T_FLOAT[3], T_FLOAT[3],
 enum TypeNames { Positions = 0, Velocities = 1, Forces = 2,
                  Types = 3, IDs = 4, Charges = 5 };
 
-#ifdef CabanaMD_ENABLE_Cuda
+#ifdef Cabana_ENABLE_Cuda
 using MemorySpace = Cabana::CudaUVMSpace;
 #else
 using MemorySpace = Cabana::HostSpace;


### PR DESCRIPTION
This will ensure consistency with the Cabana compilation decisions. This happens to match the variables used prior to cmake